### PR TITLE
Show keyboard after one second only when view is visible

### DIFF
--- a/Toshi/Controllers/Messaging/ChatController.swift
+++ b/Toshi/Controllers/Messaging/ChatController.swift
@@ -752,9 +752,9 @@ extension ChatController: ChatInteractorOutput {
         DispatchQueue.main.async {
             if let showKeyboard = showKeyboard {
                 if showKeyboard == true {
-                    // A small delay is used here to make the inputField be able to become first responder
-                     DispatchQueue.main.asyncAfter(seconds: 0.1) {
-                        self.textInputView.inputField.becomeFirstResponder()
+                     //The keyboard is shown after a delay because the controller is busy loading the chat
+                     DispatchQueue.main.asyncAfter(seconds: 1.0) {
+                        self.showKeyboardIfViewIsShown()
                      }
                 } else {
                     self.textInputView.inputField.resignFirstResponder()
@@ -762,6 +762,12 @@ extension ChatController: ChatInteractorOutput {
             }
 
             self.buttons = buttons
+        }
+    }
+
+    func showKeyboardIfViewIsShown() {
+        if isVisible {
+            textInputView.inputField.becomeFirstResponder()
         }
     }
 

--- a/Toshi/Controllers/Messaging/ChatInteractor.swift
+++ b/Toshi/Controllers/Messaging/ChatInteractor.swift
@@ -216,7 +216,7 @@ final class ChatsInteractor {
             if interaction.hasAttachments() {
                 message.messageType = "Image"
             } else if let sofaMessage = sofaWrapper as? SofaMessage {
-                output?.didHandleSofaMessage(with: sofaMessage.buttons, showKeyboard: sofaMessage.showKeyboard)
+                self.output?.didHandleSofaMessage(with: sofaMessage.buttons, showKeyboard: sofaMessage.showKeyboard)
             } else if let paymentRequest = sofaWrapper as? SofaPaymentRequest {
                 message.messageType = "Actionable"
                 message.title = "Payment request"


### PR DESCRIPTION
Fixes this issue: https://trello.com/c/FDKhtd2y/213-improve-keyboard-handling-in-chatscontroller-chat-transition

Showing keyboard after one second make it look very smooth. I make sure to check wether the view is still visible so it wont try to show the keybord after the view is being dismissed:
![keyboard](https://user-images.githubusercontent.com/1125417/29109893-08fb7be4-7ce5-11e7-8e6f-18a5a49ff3c5.gif)
