### PR TITLE
Name viewConnections according to their type

### DIFF
--- a/Toshi/Controllers/Favorites/FavoritesController.swift
+++ b/Toshi/Controllers/Favorites/FavoritesController.swift
@@ -253,9 +253,9 @@ open class FavoritesController: SweetTableController {
 
         // If changes do not affect current view, update and return without updating collection view
         // swiftlint:disable force_cast
-        let viewConnection = uiDatabaseConnection.ext(TSThreadDatabaseViewExtensionName) as! YapDatabaseViewConnection
+        let threadViewConnection = uiDatabaseConnection.ext(TSThreadDatabaseViewExtensionName) as! YapDatabaseViewConnection
         // swiftlint:enable force_cast
-        let hasChangesForCurrentView = viewConnection.hasChanges(for: notifications)
+        let hasChangesForCurrentView = threadViewConnection.hasChanges(for: notifications)
         if !hasChangesForCurrentView {
             uiDatabaseConnection.read { transaction in
                 self.mappings.update(with: transaction)
@@ -264,7 +264,7 @@ open class FavoritesController: SweetTableController {
             return
         }
 
-        let yapDatabaseChanges = viewConnection.getChangesFor(notifications: notifications, with: mappings)
+        let yapDatabaseChanges = threadViewConnection.getChangesFor(notifications: notifications, with: mappings)
         let isDatabaseChanged = yapDatabaseChanges.rowChanges.count != 0 || yapDatabaseChanges.sectionChanges.count != 0
 
         guard isDatabaseChanged, !searchController.isActive else { return }

--- a/Toshi/Controllers/Messaging/ChatViewModel.swift
+++ b/Toshi/Controllers/Messaging/ChatViewModel.swift
@@ -179,9 +179,9 @@ final class ChatViewModel {
         // TODO: Since this is used in more than one place, we should look into abstracting this away, into our own
         // table/collection view backing model.
         // swiftlint:disable force_cast
-        let viewConnection = uiDatabaseConnection.ext(TSMessageDatabaseViewExtensionName) as! YapDatabaseViewConnection
+        let messageViewConnection = uiDatabaseConnection.ext(TSMessageDatabaseViewExtensionName) as! YapDatabaseViewConnection
         // swiftlint:enable force_cast
-        if let hasChangesForCurrentView = viewConnection.hasChanges(for: notifications) as Bool?, hasChangesForCurrentView == false {
+        if let hasChangesForCurrentView = messageViewConnection.hasChanges(for: notifications) as Bool?, hasChangesForCurrentView == false {
             uiDatabaseConnection.read { transaction in
                 self.mappings.update(with: transaction)
             }
@@ -189,7 +189,7 @@ final class ChatViewModel {
             return
         }
 
-        let yapDatabaseChanges = viewConnection.getChangesFor(notifications: notifications, with: mappings)
+        let yapDatabaseChanges = messageViewConnection.getChangesFor(notifications: notifications, with: mappings)
 
         uiDatabaseConnection.asyncRead { [weak self] transaction in
             guard let strongSelf = self else { return }

--- a/Toshi/Controllers/Messaging/ChatsController.swift
+++ b/Toshi/Controllers/Messaging/ChatsController.swift
@@ -131,10 +131,10 @@ open class ChatsController: SweetTableController {
 
         // If changes do not affect current view, update and return without updating collection view
         // swiftlint:disable force_cast
-        let viewConnection = uiDatabaseConnection.ext(TSThreadDatabaseViewExtensionName) as! YapDatabaseViewConnection
+        let threadViewConnection = uiDatabaseConnection.ext(TSThreadDatabaseViewExtensionName) as! YapDatabaseViewConnection
         // swiftlint:enable force_cast
 
-        let hasChangesForCurrentView = viewConnection.hasChanges(for: notifications)
+        let hasChangesForCurrentView = threadViewConnection.hasChanges(for: notifications)
         if !hasChangesForCurrentView {
             uiDatabaseConnection.read { transaction in
                 self.mappings.update(with: transaction)
@@ -143,7 +143,7 @@ open class ChatsController: SweetTableController {
             return
         }
 
-        let yapDatabaseChanges = viewConnection.getChangesFor(notifications: notifications, with: mappings)
+        let yapDatabaseChanges = threadViewConnection.getChangesFor(notifications: notifications, with: mappings)
         let isDatabaseChanged = yapDatabaseChanges.rowChanges.count != 0 || yapDatabaseChanges.sectionChanges.count != 0
 
         guard isDatabaseChanged else { return }


### PR DESCRIPTION
Because of the mistake i made earlier with using the wrong database view extension name, i thought i would add more context to the `viewConnections` by adding the type to their name. This way I hope these kind of mistakes will be easier to prevent ✌️  