### PR TITLE
[IOS-422]: Retrieve prekeys, regester user with chat service if 401 returned

### DIFF
--- a/Toshi.xcodeproj/project.pbxproj
+++ b/Toshi.xcodeproj/project.pbxproj
@@ -121,6 +121,9 @@
 		2BD0A4D11FDEAAF900D745BF /* PrekeysRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD0A4D01FDEAAF900D745BF /* PrekeysRequest.m */; };
 		2BD0A4D21FDEAAF900D745BF /* PrekeysRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD0A4D01FDEAAF900D745BF /* PrekeysRequest.m */; };
 		2BD0A4D31FDEAAF900D745BF /* PrekeysRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD0A4D01FDEAAF900D745BF /* PrekeysRequest.m */; };
+		2BD0A4D61FDEBDCB00D745BF /* PreKeyHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD0A4D51FDEBDCB00D745BF /* PreKeyHandler.m */; };
+		2BD0A4D71FDEBDCB00D745BF /* PreKeyHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD0A4D51FDEBDCB00D745BF /* PreKeyHandler.m */; };
+		2BD0A4D81FDEBDCB00D745BF /* PreKeyHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD0A4D51FDEBDCB00D745BF /* PreKeyHandler.m */; };
 		2BD0AC8C1F278677000D2A58 /* token.cer in Resources */ = {isa = PBXBuildFile; fileRef = 2BD0AC8B1F278677000D2A58 /* token.cer */; };
 		2BD135AE1EE1A1E000B9F454 /* SplashNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD135AD1EE1A1E000B9F454 /* SplashNavigationController.swift */; };
 		2BD135AF1EE1A1E000B9F454 /* SplashNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD135AD1EE1A1E000B9F454 /* SplashNavigationController.swift */; };
@@ -898,6 +901,8 @@
 		2BC85F7E1F0F946600BCB171 /* InputCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputCell.swift; sourceTree = "<group>"; };
 		2BD0A4CF1FDEAAF800D745BF /* PrekeysRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrekeysRequest.h; sourceTree = "<group>"; };
 		2BD0A4D01FDEAAF900D745BF /* PrekeysRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PrekeysRequest.m; sourceTree = "<group>"; };
+		2BD0A4D41FDEBDCB00D745BF /* PreKeyHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PreKeyHandler.h; sourceTree = "<group>"; };
+		2BD0A4D51FDEBDCB00D745BF /* PreKeyHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PreKeyHandler.m; sourceTree = "<group>"; };
 		2BD0AC8B1F278677000D2A58 /* token.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = token.cer; sourceTree = "<group>"; };
 		2BD135AD1EE1A1E000B9F454 /* SplashNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SplashNavigationController.swift; sourceTree = "<group>"; };
 		2BD6FB3F1F02927F00F1E2BF /* IndexPath+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IndexPath+Additions.swift"; sourceTree = "<group>"; };
@@ -1561,6 +1566,8 @@
 			children = (
 				9F9238B71E24F1D2004BEEE0 /* AppDelegate.h */,
 				9F9238B81E24F1D2004BEEE0 /* AppDelegate.m */,
+				2BD0A4D41FDEBDCB00D745BF /* PreKeyHandler.h */,
+				2BD0A4D51FDEBDCB00D745BF /* PreKeyHandler.m */,
 				9FF00E351EB20F3500A854A8 /* EmptyCallHandler.h */,
 				9FF00E361EB20F3500A854A8 /* EmptyCallHandler.m */,
 				D197BC29CA8C5D37D1FA122F /* TestAppDelegate.h */,
@@ -2984,6 +2991,7 @@
 				149F9AA71E72E29A00FB74AA /* NSDecimalNumber+Additions.swift in Sources */,
 				A9AC74121E78064500365029 /* TextLabel.swift in Sources */,
 				149F9AAC1E72E29A00FB74AA /* AppsAPIClient.swift in Sources */,
+				2BD0A4D81FDEBDCB00D745BF /* PreKeyHandler.m in Sources */,
 				149F9AAD1E72E29A00FB74AA /* QRCodeController.swift in Sources */,
 				A91629131F3C6611008A7F36 /* PaymentAddressInputView.swift in Sources */,
 				149F9AAE1E72E29A00FB74AA /* PaymentController.swift in Sources */,
@@ -3178,6 +3186,7 @@
 				A9191DD01F2220C100498A4F /* BalanceController.swift in Sources */,
 				9F21625F1E5EF39B00292B14 /* EthereumNotificationHandler.swift in Sources */,
 				2BC6925D1EE937E800285070 /* Emptiable.swift in Sources */,
+				2BD0A4D61FDEBDCB00D745BF /* PreKeyHandler.m in Sources */,
 				9FCDBADF1E28E6DC00A70E07 /* TabBarController.swift in Sources */,
 				A9ED6CCD1E82B57E00160637 /* InputField.swift in Sources */,
 				9FAE4A6B1E4CBFC400126217 /* NSDecimalNumber+Additions.swift in Sources */,
@@ -3372,6 +3381,7 @@
 				A9603F111F4DABDC00BF57B1 /* NSDecimalNumber+Additions.swift in Sources */,
 				A9603F131F4DABDC00BF57B1 /* TextLabel.swift in Sources */,
 				A9603F141F4DABDC00BF57B1 /* AppsAPIClient.swift in Sources */,
+				2BD0A4D71FDEBDCB00D745BF /* PreKeyHandler.m in Sources */,
 				A9603F181F4DABDC00BF57B1 /* QRCodeController.swift in Sources */,
 				A9603F191F4DABDC00BF57B1 /* PaymentAddressInputView.swift in Sources */,
 				A9603F1E1F4DABDC00BF57B1 /* PaymentController.swift in Sources */,

--- a/Toshi.xcodeproj/project.pbxproj
+++ b/Toshi.xcodeproj/project.pbxproj
@@ -118,6 +118,9 @@
 		2BC85F7D1F0F939C00BCB171 /* InputCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2BC85F7B1F0F939C00BCB171 /* InputCell.xib */; };
 		2BC85F7F1F0F946600BCB171 /* InputCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BC85F7E1F0F946600BCB171 /* InputCell.swift */; };
 		2BC85F801F0F946600BCB171 /* InputCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BC85F7E1F0F946600BCB171 /* InputCell.swift */; };
+		2BD0A4D11FDEAAF900D745BF /* PrekeysRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD0A4D01FDEAAF900D745BF /* PrekeysRequest.m */; };
+		2BD0A4D21FDEAAF900D745BF /* PrekeysRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD0A4D01FDEAAF900D745BF /* PrekeysRequest.m */; };
+		2BD0A4D31FDEAAF900D745BF /* PrekeysRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BD0A4D01FDEAAF900D745BF /* PrekeysRequest.m */; };
 		2BD0AC8C1F278677000D2A58 /* token.cer in Resources */ = {isa = PBXBuildFile; fileRef = 2BD0AC8B1F278677000D2A58 /* token.cer */; };
 		2BD135AE1EE1A1E000B9F454 /* SplashNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD135AD1EE1A1E000B9F454 /* SplashNavigationController.swift */; };
 		2BD135AF1EE1A1E000B9F454 /* SplashNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD135AD1EE1A1E000B9F454 /* SplashNavigationController.swift */; };
@@ -893,6 +896,8 @@
 		2BC7CA291F7BA60600033E35 /* UIViewController+NavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+NavigationBar.swift"; sourceTree = "<group>"; };
 		2BC85F7B1F0F939C00BCB171 /* InputCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = InputCell.xib; sourceTree = "<group>"; };
 		2BC85F7E1F0F946600BCB171 /* InputCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputCell.swift; sourceTree = "<group>"; };
+		2BD0A4CF1FDEAAF800D745BF /* PrekeysRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrekeysRequest.h; sourceTree = "<group>"; };
+		2BD0A4D01FDEAAF900D745BF /* PrekeysRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PrekeysRequest.m; sourceTree = "<group>"; };
 		2BD0AC8B1F278677000D2A58 /* token.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = token.cer; sourceTree = "<group>"; };
 		2BD135AD1EE1A1E000B9F454 /* SplashNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SplashNavigationController.swift; sourceTree = "<group>"; };
 		2BD6FB3F1F02927F00F1E2BF /* IndexPath+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IndexPath+Additions.swift"; sourceTree = "<group>"; };
@@ -1383,6 +1388,8 @@
 			isa = PBXGroup;
 			children = (
 				2B002D8E1F17BA1800D92240 /* NetworkSwitcher.swift */,
+				2BD0A4CF1FDEAAF800D745BF /* PrekeysRequest.h */,
+				2BD0A4D01FDEAAF900D745BF /* PrekeysRequest.m */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -2989,6 +2996,7 @@
 				D197B6A1519FAB078F9174F4 /* BlurView.swift in Sources */,
 				A9CADC341F94B1E10096D017 /* BrowseCollectionViewCell.swift in Sources */,
 				D197B83F0A9396CF2E7628D5 /* ActiveNetworkView.swift in Sources */,
+				2BD0A4D31FDEAAF900D745BF /* PrekeysRequest.m in Sources */,
 				D197BEB965F76FE14EF90555 /* ActiveNetworkDisplaying.swift in Sources */,
 				D197B11DD70DB5696FFC4FD2 /* UINotificationName+Additions.swift in Sources */,
 				D197B968EE5E2CE52CC92F1D /* YapDatabaseViewConnection+Additions.swift in Sources */,
@@ -3182,6 +3190,7 @@
 				A9CADC201F94AF2D0096D017 /* ReputationView.swift in Sources */,
 				9F9B25551ECB1BC0007B435A /* ContactActionView.swift in Sources */,
 				D197B6D91E419A23890C7E8B /* BlurView.swift in Sources */,
+				2BD0A4D11FDEAAF900D745BF /* PrekeysRequest.m in Sources */,
 				6AE44D971F45C38B00F5AF02 /* CurrencyPicker.swift in Sources */,
 				D197BC32BA4D952C0E815F18 /* ActiveNetworkView.swift in Sources */,
 				D197B401E977724E946A55BE /* ActiveNetworkDisplaying.swift in Sources */,
@@ -3375,6 +3384,7 @@
 				A9603F321F4DABDC00BF57B1 /* BlurView.swift in Sources */,
 				A9CADC331F94B1E00096D017 /* BrowseCollectionViewCell.swift in Sources */,
 				A9603F331F4DABDC00BF57B1 /* ActiveNetworkView.swift in Sources */,
+				2BD0A4D21FDEAAF900D745BF /* PrekeysRequest.m in Sources */,
 				A9603F341F4DABDC00BF57B1 /* ActiveNetworkDisplaying.swift in Sources */,
 				A9603F351F4DABDC00BF57B1 /* UINotificationName+Additions.swift in Sources */,
 				A9603F361F4DABDC00BF57B1 /* YapDatabaseViewConnection+Additions.swift in Sources */,

--- a/Toshi/Models/UserBootstrapParameters.swift
+++ b/Toshi/Models/UserBootstrapParameters.swift
@@ -21,17 +21,7 @@ class UserBootstrapParameter {
 
     // This change might require re-creating Signal users
     lazy var password: String = {
-        let deviceSpecificPasswordKey = "DeviceSpecificPassword"
-        let uuid: String
-
-        if let storedUUID = Yap.sharedInstance.retrieveObject(for: deviceSpecificPasswordKey) as? String {
-            uuid = storedUUID
-        } else {
-            uuid = UUID().uuidString
-            Yap.sharedInstance.insert(object: uuid, for: deviceSpecificPasswordKey)
-        }
-
-        return uuid
+        return UUID().uuidString
     }()
 
     let identityKey: String

--- a/Toshi/Network/PrekeysRequest.h
+++ b/Toshi/Network/PrekeysRequest.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2017 Token Browser, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import <Foundation/Foundation.h>
+#import "TSRequest.h"
+@class TSContact;
+
+@interface PrekeysRequest : TSRequest
+
+- (instancetype)initWithURL:(NSURL *)URL;
+
+@end
+

--- a/Toshi/Network/PrekeysRequest.m
+++ b/Toshi/Network/PrekeysRequest.m
@@ -1,0 +1,32 @@
+// Copyright (c) 2017 Token Browser, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import "PrekeysRequest.h"
+#import "TSRecipientPrekeyRequest.h"
+#import <SignalServiceKit/TSConstants.h>
+
+@implementation PrekeysRequest
+
+- (instancetype)initWithURL:(NSURL *)URL
+{
+    self = [super initWithURL:URL];
+
+    self.HTTPMethod = @"GET";
+    self.parameters = nil;
+
+    return self;
+}
+
+@end

--- a/Toshi/Supporting Files/AppDelegate.m
+++ b/Toshi/Supporting Files/AppDelegate.m
@@ -18,12 +18,11 @@
 #import <SignalServiceKit/OWSDispatch.h>
 #import <SignalServiceKit/ProfileManagerProtocol.h>
 #import "ProfileManager.h"
-#import "PrekeysRequest.h"
 
 #import <AxolotlKit/SessionCipher.h>
+#import "PreKeyHandler.h"
 
 NSString *const ChatSertificateName = @"token";
-NSUInteger const PREKEY_MINIMUM_COUNT = 20;
 
 @import WebRTC;
 
@@ -382,57 +381,7 @@ NSUInteger const PREKEY_MINIMUM_COUNT = 20;
     [self configureAndPresentWindow];
     [SignalNotificationManager updateUnreadMessagesNumber];
 
-    [self tryRetrievingPrekeys];
-}
-
-- (void)tryRetrievingPrekeys
-{
-    NSURL *url = [NSURL URLWithString:textSecureKeysAPI];
-
-    __weak typeof(self) weakSelf = self;
-    [self.networkManager makeRequest:[[PrekeysRequest alloc] initWithURL:url] success:^(NSURLSessionDataTask * _Nonnull task, id  _Nonnull responseObject) {
-
-        typeof(self)strongSelf = weakSelf;
-
-        NSDictionary *responseDict = (NSDictionary *)responseObject;
-        NSInteger prekeysCount = [responseDict[@"count"] integerValue];
-        if (prekeysCount < PREKEY_MINIMUM_COUNT) {
-            [strongSelf refreshPrekeys];
-        }
-    } failure:^(NSURLSessionDataTask * _Nonnull task, NSError * _Nonnull error) {
-
-        [CrashlyticsLogger log:@"Failed retrieve prekeys - triggering Chat register" attributes:nil];
-
-        if (error.code == 401) {
-            [ChatAPIClient.shared registerUserWithCompletion:^(BOOL success) {
-                if (success) {
-                    [CrashlyticsLogger log:@"Successfully registered user with chat service after forced trigger" attributes:nil];
-                } else {
-                    [CrashlyticsLogger log:@"Failed to register user with chat service after forced trigger" attributes:nil];
-                }
-            }];
-        }
-    }];
-}
-
-- (void)refreshPrekeys
-{
-    [TSPreKeyManager registerPreKeysWithMode:RefreshPreKeysMode_SignedAndOneTime
-                                     success:^{
-                                         [CrashlyticsLogger log:@"Successfully refreshed prekeys" attributes:nil];
-                                     } failure:^(NSError *error) {
-                                         [CrashlyticsLogger log:@"Failed registering prekeys - triggering Chat register" attributes:nil];
-
-                                         if (error.code == 401) {
-                                             [ChatAPIClient.shared registerUserWithCompletion:^(BOOL success) {
-                                                 if (success) {
-                                                     [CrashlyticsLogger log:@"Successfully registered user with chat service after forced trigger" attributes:nil];
-                                                 } else {
-                                                     [CrashlyticsLogger log:@"Failed to register user with chat service after forced trigger" attributes:nil];
-                                                 }
-                                             }];
-                                         }
-                                     }];
+    [PreKeyHandler tryRetrievingPrekeys];
 }
 
 - (void)deactivateScreenProtection

--- a/Toshi/Supporting Files/AppDelegate.m
+++ b/Toshi/Supporting Files/AppDelegate.m
@@ -387,8 +387,7 @@ NSUInteger const PREKEY_MINIMUM_COUNT = 20;
 
 - (void)tryRetrievingPrekeys
 {
-    NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"%@",
-                                       textSecureKeysAPI]];
+    NSURL *url = [NSURL URLWithString:textSecureKeysAPI];
 
     __weak typeof(self) weakSelf = self;
     [self.networkManager makeRequest:[[PrekeysRequest alloc] initWithURL:url] success:^(NSURLSessionDataTask * _Nonnull task, id  _Nonnull responseObject) {

--- a/Toshi/Supporting Files/PreKeyHandler.h
+++ b/Toshi/Supporting Files/PreKeyHandler.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2017 Token Browser, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import <Foundation/Foundation.h>
+
+@interface PreKeyHandler : NSObject
+
++ (void)tryRetrievingPrekeys;
+
+@end

--- a/Toshi/Supporting Files/PreKeyHandler.m
+++ b/Toshi/Supporting Files/PreKeyHandler.m
@@ -1,0 +1,78 @@
+// Copyright (c) 2017 Token Browser, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#import <Foundation/Foundation.h>
+#import "PreKeyHandler.h"
+#import "PrekeysRequest.h"
+#import <SignalServiceKit/TSNetworkManager.h>
+#import <SignalServiceKit/TSPreKeyManager.h>
+#import "Toshi-Swift.h"
+
+NSUInteger const PREKEY_MINIMUM_COUNT = 20;
+
+@implementation PreKeyHandler
+
++ (void)tryRetrievingPrekeys
+{
+    NSURL *url = [NSURL URLWithString:textSecureKeysAPI];
+
+    TSNetworkManager *networkManager = [TSNetworkManager sharedManager];
+    __weak typeof(self) weakSelf = self;
+    [networkManager makeRequest:[[PrekeysRequest alloc] initWithURL:url] success:^(NSURLSessionDataTask * _Nonnull task, id  _Nonnull responseObject) {
+
+        typeof(self)strongSelf = weakSelf;
+
+        NSDictionary *responseDict = (NSDictionary *)responseObject;
+        NSInteger prekeysCount = [responseDict[@"count"] integerValue];
+        if (prekeysCount < PREKEY_MINIMUM_COUNT) {
+            [strongSelf refreshPrekeys];
+        }
+    } failure:^(NSURLSessionDataTask * _Nonnull task, NSError * _Nonnull error) {
+
+        [CrashlyticsLogger log:@"Failed retrieve prekeys - triggering Chat register" attributes:nil];
+
+        if (error.code == 401) {
+            [ChatAPIClient.shared registerUserWithCompletion:^(BOOL success) {
+                if (success) {
+                    [CrashlyticsLogger log:@"Successfully registered user with chat service after forced trigger" attributes:nil];
+                } else {
+                    [CrashlyticsLogger log:@"Failed to register user with chat service after forced trigger" attributes:nil];
+                }
+            }];
+        }
+    }];
+}
+
++ (void)refreshPrekeys
+{
+    [TSPreKeyManager registerPreKeysWithMode:RefreshPreKeysMode_SignedAndOneTime
+                                     success:^{
+                                         [CrashlyticsLogger log:@"Successfully refreshed prekeys" attributes:nil];
+                                     } failure:^(NSError *error) {
+                                         [CrashlyticsLogger log:@"Failed registering prekeys - triggering Chat register" attributes:nil];
+
+                                         if (error.code == 401) {
+                                             [ChatAPIClient.shared registerUserWithCompletion:^(BOOL success) {
+                                                 if (success) {
+                                                     [CrashlyticsLogger log:@"Successfully registered user with chat service after forced trigger" attributes:nil];
+                                                 } else {
+                                                     [CrashlyticsLogger log:@"Failed to register user with chat service after forced trigger" attributes:nil];
+                                                 }
+                                             }];
+                                         }
+                                     }];
+}
+
+@end

--- a/Toshi/Utilities/UserDefaultsWrapper.swift
+++ b/Toshi/Utilities/UserDefaultsWrapper.swift
@@ -30,8 +30,7 @@ enum UserDefaultsKey: String, StringCaseListable {
     selectedApp = "Restoration::SelectedApp",
     selectedContact = "Restoration::SelectedContact",
     selectedThreadAddress = "Restoration::SelectedThread",
-    tabBarSelectedIndex = "TabBarSelectedIndex",
-    chatRegistrationUpdateTriggered = "Restoration::ChatRegistrationUpdateTriggered"
+    tabBarSelectedIndex = "TabBarSelectedIndex"
 }
 
 /// A wrapper for NSUserDefaults to facilitate type-safe fetching
@@ -99,17 +98,6 @@ class UserDefaultsWrapper: NSObject {
         }
         set {
             setValue(newValue, for: .addressChangeAlertShown)
-        }
-    }
-
-    /// Looks at whether user's prekeys were checked once after db loss issue
-    /// and in case of failure chat registration was executed
-    @objc static var chatRegistrationUpdateTriggered: Bool {
-        get {
-            return bool(for: .chatRegistrationUpdateTriggered)
-        }
-        set {
-            setValue(newValue, for: .chatRegistrationUpdateTriggered)
         }
     }
     


### PR DESCRIPTION
Also:
remove not needed key from UserDefaults wrapper;
do not store network requests password in database, create new one each login;
refresh prekeys if there are less then desirable amount left (defines by constant of `20`, same as used in bots code).