### PR TITLE
[IOS-427] Fix avatar border color

### DIFF
--- a/Toshi/Views/AvatarImageView.swift
+++ b/Toshi/Views/AvatarImageView.swift
@@ -44,7 +44,7 @@ class AvatarImageView: UIImageView {
     private func setup() {
         clipsToBounds = true
         contentMode = .scaleAspectFill
-        layer.borderColor = UIColor.black.withAlphaComponent(0.2).cgColor
+        layer.borderColor = UIColor.black.withAlphaComponent(0.15).cgColor
         layer.borderWidth = .lineHeight
     }
 

--- a/Toshi/Views/AvatarImageView.swift
+++ b/Toshi/Views/AvatarImageView.swift
@@ -44,7 +44,7 @@ class AvatarImageView: UIImageView {
     private func setup() {
         clipsToBounds = true
         contentMode = .scaleAspectFill
-        layer.borderColor = Theme.borderColor.cgColor
+        layer.borderColor = UIColor.black.withAlphaComponent(0.2).cgColor
         layer.borderWidth = .lineHeight
     }
 


### PR DESCRIPTION
The border should have a transparent color to overlay the avatar image.

https://toshiapp.atlassian.net/browse/IOS-427
