### PR TITLE
Change the constant of the height constraint

### DIFF
--- a/Toshi/Controllers/Browse/DappViewController.swift
+++ b/Toshi/Controllers/Browse/DappViewController.swift
@@ -77,8 +77,8 @@ final class DappViewController: UIViewController {
         stackView.addArrangedSubview(descriptionLabel)
         stackView.addArrangedSubview(urlLabel)
         stackView.addArrangedSubview(enterButton)
-        
-        enterButton.height(44)
+
+        enterButton.heightConstraint.constant = 44
         
         return stackView
     }()
@@ -104,13 +104,7 @@ final class DappViewController: UIViewController {
         
         let topAnchor: NSLayoutYAxisAnchor
         
-        if #available(iOS 11.0, *) {
-            topAnchor = view.safeAreaLayoutGuide.topAnchor
-        } else {
-            topAnchor = view.topAnchor
-        }
-        
-        primaryStackView.top(to: view, topAnchor, offset: 16)
+        primaryStackView.top(to: layoutGuide(), offset: 16)
         primaryStackView.leftToSuperview(offset: 16)
         primaryStackView.rightToSuperview(offset: 16)
     


### PR DESCRIPTION
I got a constraint crash when opening a Dapp-view

It seems like the ActionButton set it's on constraint, I find it a bit weird how it works so if you think rewriting it would be better just let me know.

By setting the constant of the heightConstraint instead of a (nother) height constraint directly it doesnt crash at least.

I also implemented an extension method for the switch between safe area and layoutguides in ios 10 and 11.