### PR TITLE
Improve Payment Modal Animation

### DIFF
--- a/Tests/IDAPIClientTests.swift
+++ b/Tests/IDAPIClientTests.swift
@@ -143,7 +143,7 @@ class IDAPIClientTests: QuickSpec {
                     let paymentAddress = "0x1ad0bb2d14595fa6ad885e53eaaa6c82339f9b98"
 
                     waitUntil { done in
-                        subject.findUserWithPaymentAddress(paymentAddress) { user, error in
+                        subject.findUserWithPaymentAddress(paymentAddress) { user, _ in
                             expect(user).toNot(beNil())
 
                             expect(user?.name).to(equal("Marijn Schilling"))

--- a/Toshi/Controllers/Payments/PaymentConfirmationViewController.swift
+++ b/Toshi/Controllers/Payments/PaymentConfirmationViewController.swift
@@ -28,7 +28,7 @@ enum RecipientType {
 
 enum PresentationMethod {
     case
-    pushedInNav,
+    fullScreen,
     modalBottomSheet
 }
 
@@ -135,10 +135,10 @@ class PaymentConfirmationViewController: UIViewController {
         }
     }
 
-    var presentationMethod: PresentationMethod = .pushedInNav {
+    var presentationMethod: PresentationMethod = .fullScreen {
         didSet {
             switch presentationMethod {
-            case .pushedInNav:
+            case .fullScreen:
                 // Not much to do here
                 break
             case .modalBottomSheet:
@@ -268,7 +268,7 @@ class PaymentConfirmationViewController: UIViewController {
         super.viewDidLayoutSubviews()
 
         switch presentationMethod {
-        case .pushedInNav:
+        case .fullScreen:
             // do nothing
             return
         case .modalBottomSheet:
@@ -284,7 +284,7 @@ class PaymentConfirmationViewController: UIViewController {
         super.viewWillDisappear(animated)
 
         switch presentationMethod {
-        case .pushedInNav:
+        case .fullScreen:
             // Do nothing
             return
         case .modalBottomSheet:
@@ -524,7 +524,7 @@ class PaymentConfirmationViewController: UIViewController {
 
     @objc func cancelItemTapped() {
         switch presentationMethod {
-        case .pushedInNav:
+        case .fullScreen:
             actuallyDismiss()
         case .modalBottomSheet:
             self.setReceiptShowing(false) {

--- a/Toshi/Controllers/Payments/PaymentConfirmationViewController.swift
+++ b/Toshi/Controllers/Payments/PaymentConfirmationViewController.swift
@@ -279,7 +279,7 @@ class PaymentConfirmationViewController: UIViewController {
             // First, shove the receipt offscreen non-animated so the user can't see it.
             setReceiptShowing(false, animated: false)
 
-            // Then, start animating it back in. 
+            // Then, start animating it back in.
             setReceiptShowing(true)
         }
     }
@@ -448,7 +448,7 @@ class PaymentConfirmationViewController: UIViewController {
     private func setReceiptShowing(_ showing: Bool, animated: Bool = true, completion: (() -> Void)? = nil) {
         guard let bottomConstraint = bottomOfReceiptConstraint else { /* nothing to adjust yet */ return }
 
-        let targetConstraintConstant: CGFloat = showing ? .largeInterItemSpacing : view.frame.height
+        let targetConstraintConstant: CGFloat = showing ? -.largeInterItemSpacing : view.frame.height
 
         guard bottomOfReceiptConstraint?.constant != targetConstraintConstant else { /* already where we want it to be */ return }
 

--- a/Toshi/Controllers/Payments/PaymentConfirmationViewController.swift
+++ b/Toshi/Controllers/Payments/PaymentConfirmationViewController.swift
@@ -452,9 +452,12 @@ class PaymentConfirmationViewController: UIViewController {
 
         guard bottomOfReceiptConstraint?.constant != targetConstraintConstant else { /* already where we want it to be */ return }
 
-        bottomConstraint.constant = targetConstraintConstant
+        // Execute any pending layout operations before the one we want to animate
+        view.layoutIfNeeded()
+
         let options: UIViewAnimationOptions = showing ? [.curveEaseOut] : [.curveEaseIn]
         let duration = animated ? 0.4 : 0
+        bottomConstraint.constant = targetConstraintConstant
 
         UIView.animate(withDuration: duration, delay: 0, options: options, animations: {
             self.view.layoutIfNeeded()

--- a/Toshi/Controllers/Payments/PaymentConfirmationViewController.swift
+++ b/Toshi/Controllers/Payments/PaymentConfirmationViewController.swift
@@ -275,7 +275,11 @@ class PaymentConfirmationViewController: UIViewController {
             guard !hasLaidOutBefore, bottomOfReceiptConstraint != nil else { return }
 
             hasLaidOutBefore = true
+
+            // First, shove the receipt offscreen non-animated so the user can't see it.
             setReceiptShowing(false, animated: false)
+
+            // Then, start animating it back in. 
             setReceiptShowing(true)
         }
     }

--- a/Toshi/Controllers/Payments/PaymentManager.swift
+++ b/Toshi/Controllers/Payments/PaymentManager.swift
@@ -58,7 +58,7 @@ class PaymentManager {
             let totalEthereumString = EthereumConverter.ethereumValueString(forWei: totalWei)
 
             /// We don't care about the cached balance since we immediately want to know if the current balance is sufficient or not.
-            EthereumAPIClient.shared.getBalance(cachedBalanceCompletion: { _, _ in }, fetchedBalanceCompletion: { fetchedBalance, error in
+            EthereumAPIClient.shared.getBalance(cachedBalanceCompletion: { _, _ in }, fetchedBalanceCompletion: { fetchedBalance, _ in
                 //WARNING: What to do when we have an error here?
 
                 let balanceString = EthereumConverter.fiatValueStringWithCode(forWei: fetchedBalance, exchangeRate: ExchangeRateClient.exchangeRate)
@@ -74,7 +74,7 @@ class PaymentManager {
         guard let transaction = transaction else { return }
         let signedTransaction = "0x\(Cereal.shared.signWithWallet(hex: transaction))"
 
-        EthereumAPIClient.shared.sendSignedTransaction(originalTransaction: transaction, transactionSignature: signedTransaction) { success, transactionHash, error in
+        EthereumAPIClient.shared.sendSignedTransaction(originalTransaction: transaction, transactionSignature: signedTransaction) { _, transactionHash, error in
             completion(error, transactionHash)
         }
     }

--- a/Toshi/Controllers/Payments/PaymentRouter/PaymentRouter.swift
+++ b/Toshi/Controllers/Payments/PaymentRouter/PaymentRouter.swift
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import Foundation
+import UIKit
 
 protocol PaymentRouterDelegate: class {
     func paymentRouterDidCancel(paymentRouter: PaymentRouter)
@@ -72,8 +72,11 @@ final class PaymentRouter {
 
         if let dappInfo = dappInfo {
             let paymentConfirmationController = PaymentConfirmationViewController(parameters: paymentViewModel.parameters, recipientType: .dapp(info: dappInfo)) // PaymentConfirmationViewController(withValue: value, andRecipientAddress: address, gasPrice: paymentViewModel.gasPrice, recipientType: .dapp(info: dappInfo), shouldSendSignedTransaction: shouldSendSignedTransaction, skeletonParams: additionalParamaters)
+
+            paymentConfirmationController.backgroundView = Navigator.window?.snapshotView(afterScreenUpdates: false)
+
             paymentConfirmationController.delegate = self
-            paymentConfirmationController.modalPresentationStyle = .currentContext
+            paymentConfirmationController.presentationMethod = .modalBottomSheet
 
             Navigator.presentModally(paymentConfirmationController)
         } else {

--- a/Toshi/Controllers/Payments/View/ReceiptView.swift
+++ b/Toshi/Controllers/Payments/View/ReceiptView.swift
@@ -71,6 +71,9 @@ class ReceiptView: UIStackView {
 
         addWithDefaultConstraints(view: ethereumAmountLabel)
         addSpacing(.mediumInterItemSpacing, after: ethereumAmountLabel)
+
+        // Add blank text to the ethereum label so there's not a jump in size when it loads
+        ethereumAmountLabel.text = " "
     }
 
     required init(coder aDecoder: NSCoder) {

--- a/Toshi/Extensions/NSDecimalNumber+Additions.swift
+++ b/Toshi/Extensions/NSDecimalNumber+Additions.swift
@@ -73,4 +73,3 @@ extension NSDecimalNumber {
         return (result == .orderedAscending) ? false : true
     }
 }
-

--- a/Toshi/Extensions/UIStackView+Additions.swift
+++ b/Toshi/Extensions/UIStackView+Additions.swift
@@ -70,13 +70,22 @@ extension UIStackView {
     /// Adds a background view to force a background color to be drawn.
     /// https://stackoverflow.com/a/42256646/681493
     ///
-    /// - Parameter color: The color for the background.
-    func addBackground(with color: UIColor) {
+    /// - Parameters:
+    ///   - color: The color for the background.
+    ///   - margin: [Optional] The margin to add around the view. Useful when there's a margin where the view is pinned which you want to make sure has the appropriate background color. When nil, edges will simply be pinned to the stack view itself.
+    func addBackground(with color: UIColor, margin: CGFloat? = nil) {
         let background = UIView()
         background.backgroundColor = color
         
         self.addSubview(background)
-        background.edgesToSuperview()
+        if let margin = margin {
+            background.topToSuperview(offset: -margin)
+            background.leftToSuperview(offset: -margin)
+            background.rightToSuperview(offset: -margin)
+            background.bottomToSuperview(offset: margin)
+        } else {
+            background.edgesToSuperview()
+        }
     }
     
     private static let spacerTag = 12345

--- a/Toshi/Views/ActionButton.swift
+++ b/Toshi/Views/ActionButton.swift
@@ -138,7 +138,7 @@ class ActionButton: UIControl {
         activityIndicator.activityIndicatorViewStyle = .white
         activityIndicator.alpha = 0
 
-        return activityIndicator 
+        return activityIndicator
     }()
 
     lazy var heightConstraint: NSLayoutConstraint = {


### PR DESCRIPTION
In this PR: 
- Distinguish presentation style separately from content
- Now modal style looks more like the Apple pay share sheet: 

![modal](https://user-images.githubusercontent.com/1976498/35224068-0ad56764-ff84-11e7-954b-c70202375501.gif)

- Fix an issue where the size of the receipt view would jump when the ethereum exchange rate loaded.
- Fix swiftLint warnings