### PR TITLE
Update code on `activeNetworkDisplaying` to use proper check

### DIFF
--- a/Toshi/Protocols/ActiveNetworkDisplaying.swift
+++ b/Toshi/Protocols/ActiveNetworkDisplaying.swift
@@ -105,11 +105,9 @@ extension ActiveNetworkDisplaying where Self: UIViewController {
     }
 
     func updateActiveNetworkView() {
-        switch NetworkSwitcher.shared.activeNetwork {
-        case .mainNet:
+        if NetworkSwitcher.shared.isDefaultNetworkActive {
             hideActiveNetworkViewIfNeeded()
-        case .ropstenTestNetwork,
-             .toshiTestNetwork:
+        } else {
             showActiveNetworkViewIfNeeded()
             activeNetworkView.updateTitle()
         }


### PR DESCRIPTION
Missed updating this when I was updating the checks around payments.