### PR TITLE
Add tests for `HeaderGenerator`

### DIFF
--- a/Tests/EthereumAPIClientTests.swift
+++ b/Tests/EthereumAPIClientTests.swift
@@ -35,7 +35,6 @@ class EthereumAPIClientTests: QuickSpec {
                 fail("Could not generate test cereal!")
                 return
             }
-            HeaderGenerator.setTestingCereal(testCereal)
 
             context("Happy path 😎") {
                 it("creates an unsigned transaction") {

--- a/Tests/HeaderGenerationTests.swift
+++ b/Tests/HeaderGenerationTests.swift
@@ -1,0 +1,110 @@
+// Copyright (c) 2018 Token Browser, Inc
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+@testable import Toshi
+import XCTest
+
+class HeaderGenerationTests: XCTestCase {
+
+    private var testCereal: Cereal {
+        guard let cereal = Cereal(words: ["abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "about"]) else {
+            fatalError("failed to create cereal")
+        }
+        return cereal
+    }
+
+    func testGeneratingGETHeaders() {
+        let timestamp = "12345"
+        let path = "/v1/get"
+
+        let expectedHeaders = [
+            HeaderGenerator.HeaderField.timestamp.rawValue: timestamp,
+            HeaderGenerator.HeaderField.address.rawValue: "0xa391af6a522436f335b7c6486640153641847ea2",
+            HeaderGenerator.HeaderField.signature.rawValue: "0x9098476693a6e7b24a722296138c9032388beea043d8b7e8ca30f21fdd79ca2c19c47d9e6acf4dec7dfc5f09f7003470b26a23035c68ccd10ba1a3b7e924fb1a00"
+        ]
+
+        let generatedHeaders = HeaderGenerator.createGetSignatureHeaders(path: path, cereal: testCereal, timestamp: timestamp)
+
+        XCTAssertEqual(generatedHeaders, expectedHeaders)
+
+        // If you change the path, the signature should change, but the address and timestamp should be the same
+        let otherHeaders = HeaderGenerator.createGetSignatureHeaders(path: "/something/else/", cereal: testCereal, timestamp: timestamp)
+        XCTAssertEqual(otherHeaders[HeaderGenerator.HeaderField.timestamp.rawValue],
+                       generatedHeaders[HeaderGenerator.HeaderField.timestamp.rawValue])
+        XCTAssertEqual(otherHeaders[HeaderGenerator.HeaderField.address.rawValue],
+                       generatedHeaders[HeaderGenerator.HeaderField.address.rawValue])
+        XCTAssertNotEqual(otherHeaders[HeaderGenerator.HeaderField.signature.rawValue],
+                          generatedHeaders[HeaderGenerator.HeaderField.signature.rawValue])
+    }
+
+    func testGeneratingPOSTHeadersFromDictionary() {
+        let path = "/v1/profile"
+        let timestamp = "44444444"
+
+        let testDictionary = [ "foo": "bar" ]
+
+        let dictionaryGeneratedHeaders: [String: String]
+        do {
+            dictionaryGeneratedHeaders = try HeaderGenerator.createHeaders(timestamp: timestamp, path: path, cereal: testCereal, payloadDictionary: testDictionary)
+        } catch let error {
+            XCTFail("Error creating headers from dictionary: \(error)")
+            return
+        }
+
+        let expectedHeaders = [
+            HeaderGenerator.HeaderField.timestamp.rawValue: timestamp,
+            HeaderGenerator.HeaderField.address.rawValue: "0xa391af6a522436f335b7c6486640153641847ea2",
+            HeaderGenerator.HeaderField.signature.rawValue: "0xea4780cd5f72dea31826d6ed44cdafc9b867165742a67d990abc8132d6c8678e5671fd78d2e4e53dbc8b49916e09be52a3c3e826253242d9b6810596bf76012300"
+        ]
+
+        XCTAssertEqual(dictionaryGeneratedHeaders, expectedHeaders)
+
+        // Changing just the path should create a different signature
+        let pathChangedHeaders: [String: String]
+        do {
+            pathChangedHeaders = try HeaderGenerator.createHeaders(timestamp: timestamp, path: (path + "/"), cereal: testCereal, payloadDictionary: testDictionary)
+        } catch let error {
+            XCTFail("Error creating path changed headers from dictionary: \(error)")
+            return
+        }
+
+        XCTAssertEqual(pathChangedHeaders[HeaderGenerator.HeaderField.timestamp.rawValue],
+                       dictionaryGeneratedHeaders[HeaderGenerator.HeaderField.timestamp.rawValue])
+        XCTAssertEqual(pathChangedHeaders[HeaderGenerator.HeaderField.address.rawValue],
+                       dictionaryGeneratedHeaders[HeaderGenerator.HeaderField.address.rawValue])
+        XCTAssertNotEqual(pathChangedHeaders[HeaderGenerator.HeaderField.signature.rawValue],
+                          dictionaryGeneratedHeaders[HeaderGenerator.HeaderField.signature.rawValue])
+
+        // Changing just the payload should create a different signature
+        let changedPayloadHeaders: [String: String]
+        do {
+            changedPayloadHeaders = try HeaderGenerator.createHeaders(timestamp: timestamp, path: path, cereal: testCereal, payloadDictionary: [ "foo": "baz" ])
+        } catch let error {
+            XCTFail("Error creating changed payload headers: \(error)")
+            return
+        }
+
+        XCTAssertEqual(changedPayloadHeaders[HeaderGenerator.HeaderField.timestamp.rawValue],
+                       dictionaryGeneratedHeaders[HeaderGenerator.HeaderField.timestamp.rawValue])
+        XCTAssertEqual(changedPayloadHeaders[HeaderGenerator.HeaderField.address.rawValue],
+                       dictionaryGeneratedHeaders[HeaderGenerator.HeaderField.address.rawValue])
+        XCTAssertNotEqual(changedPayloadHeaders[HeaderGenerator.HeaderField.signature.rawValue],
+                          dictionaryGeneratedHeaders[HeaderGenerator.HeaderField.signature.rawValue])
+        XCTAssertNotEqual(changedPayloadHeaders[HeaderGenerator.HeaderField.signature.rawValue],
+                          pathChangedHeaders[HeaderGenerator.HeaderField.signature.rawValue])
+
+    }
+
+}

--- a/Tests/HeaderGenerationTests.swift
+++ b/Tests/HeaderGenerationTests.swift
@@ -75,7 +75,7 @@ class HeaderGenerationTests: XCTestCase {
                 shouldMatch: false)
     }
 
-    func testGeneratingPOSTHeadersFromDictionary() {
+    func testGeneratingHeadersFromDictionary() {
         let path = "/v1/profile"
         let timestamp = "44444444"
 
@@ -146,6 +146,39 @@ class HeaderGenerationTests: XCTestCase {
                 toValueIn: changedPayloadHeaders,
                 shouldMatch: false)
 
+        // Changing just the method should change the signature
+        let changedMethodHeaders: [String: String]
+        do {
+            changedMethodHeaders = try HeaderGenerator.createHeaders(timestamp: timestamp, path: path, method: .PUT, cereal: testCereal, payloadDictionary: testDictionary)
+        } catch let error {
+            XCTFail("Error creating headers from dictionary: \(error)")
+            return
+        }
+
+        compare(valueFor: .timestamp,
+                inExpectedDictionary: expectedHeaders,
+                toValueIn: changedMethodHeaders)
+
+        compare(valueFor: .address,
+                inExpectedDictionary: expectedHeaders,
+                toValueIn: changedMethodHeaders)
+
+        compare(valueFor: .signature,
+                inExpectedDictionary: expectedHeaders,
+                toValueIn: changedMethodHeaders,
+                shouldMatch: false)
+
+        compare(valueFor: .signature,
+                inExpectedDictionary: changedPayloadHeaders,
+                toValueIn: changedMethodHeaders,
+                shouldMatch: false)
+
+        compare(valueFor: .signature,
+                inExpectedDictionary: pathChangedHeaders,
+                toValueIn: changedMethodHeaders,
+                shouldMatch: false)
+
+    }
     }
 
 }

--- a/Tests/HeaderGenerationTests.swift
+++ b/Tests/HeaderGenerationTests.swift
@@ -25,6 +25,26 @@ class HeaderGenerationTests: XCTestCase {
         return cereal
     }
 
+    private func compare(valueFor field: HeaderGenerator.HeaderField,
+                         inExpectedDictionary expectedDictionary: [String: String],
+                         toValueIn receivedDictionary: [String: String],
+                         shouldMatch: Bool = true,
+                         file: StaticString = #file,
+                         line: UInt = #line) {
+        let expectedValue = expectedDictionary[field.rawValue]
+        let receivedValue = receivedDictionary[field.rawValue]
+
+        if shouldMatch {
+            XCTAssertEqual(expectedValue, receivedValue,
+                           file: file,
+                           line: line)
+        } else {
+            XCTAssertNotEqual(expectedValue, receivedValue,
+                              file: file,
+                              line: line)
+        }
+    }
+
     func testGeneratingGETHeaders() {
         let timestamp = "12345"
         let path = "/v1/get"
@@ -41,12 +61,18 @@ class HeaderGenerationTests: XCTestCase {
 
         // If you change the path, the signature should change, but the address and timestamp should be the same
         let otherHeaders = HeaderGenerator.createGetSignatureHeaders(path: "/something/else/", cereal: testCereal, timestamp: timestamp)
-        XCTAssertEqual(otherHeaders[HeaderGenerator.HeaderField.timestamp.rawValue],
-                       generatedHeaders[HeaderGenerator.HeaderField.timestamp.rawValue])
-        XCTAssertEqual(otherHeaders[HeaderGenerator.HeaderField.address.rawValue],
-                       generatedHeaders[HeaderGenerator.HeaderField.address.rawValue])
-        XCTAssertNotEqual(otherHeaders[HeaderGenerator.HeaderField.signature.rawValue],
-                          generatedHeaders[HeaderGenerator.HeaderField.signature.rawValue])
+        compare(valueFor: .timestamp,
+                inExpectedDictionary: expectedHeaders,
+                toValueIn: otherHeaders)
+
+        compare(valueFor: .address,
+                inExpectedDictionary: expectedHeaders,
+                toValueIn: otherHeaders)
+
+        compare(valueFor: .signature,
+                inExpectedDictionary: expectedHeaders,
+                toValueIn: otherHeaders,
+                shouldMatch: false)
     }
 
     func testGeneratingPOSTHeadersFromDictionary() {
@@ -80,12 +106,18 @@ class HeaderGenerationTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(pathChangedHeaders[HeaderGenerator.HeaderField.timestamp.rawValue],
-                       dictionaryGeneratedHeaders[HeaderGenerator.HeaderField.timestamp.rawValue])
-        XCTAssertEqual(pathChangedHeaders[HeaderGenerator.HeaderField.address.rawValue],
-                       dictionaryGeneratedHeaders[HeaderGenerator.HeaderField.address.rawValue])
-        XCTAssertNotEqual(pathChangedHeaders[HeaderGenerator.HeaderField.signature.rawValue],
-                          dictionaryGeneratedHeaders[HeaderGenerator.HeaderField.signature.rawValue])
+        compare(valueFor: .timestamp,
+                inExpectedDictionary: expectedHeaders,
+                toValueIn: pathChangedHeaders)
+
+        compare(valueFor: .address,
+                inExpectedDictionary: expectedHeaders,
+                toValueIn: pathChangedHeaders)
+
+        compare(valueFor: .signature,
+                inExpectedDictionary: expectedHeaders,
+                toValueIn: pathChangedHeaders,
+                shouldMatch: false)
 
         // Changing just the payload should create a different signature
         let changedPayloadHeaders: [String: String]
@@ -96,14 +128,23 @@ class HeaderGenerationTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(changedPayloadHeaders[HeaderGenerator.HeaderField.timestamp.rawValue],
-                       dictionaryGeneratedHeaders[HeaderGenerator.HeaderField.timestamp.rawValue])
-        XCTAssertEqual(changedPayloadHeaders[HeaderGenerator.HeaderField.address.rawValue],
-                       dictionaryGeneratedHeaders[HeaderGenerator.HeaderField.address.rawValue])
-        XCTAssertNotEqual(changedPayloadHeaders[HeaderGenerator.HeaderField.signature.rawValue],
-                          dictionaryGeneratedHeaders[HeaderGenerator.HeaderField.signature.rawValue])
-        XCTAssertNotEqual(changedPayloadHeaders[HeaderGenerator.HeaderField.signature.rawValue],
-                          pathChangedHeaders[HeaderGenerator.HeaderField.signature.rawValue])
+        compare(valueFor: .timestamp,
+                inExpectedDictionary: expectedHeaders,
+                toValueIn: changedPayloadHeaders)
+
+        compare(valueFor: .address,
+                inExpectedDictionary: expectedHeaders,
+                toValueIn: changedPayloadHeaders)
+
+        compare(valueFor: .signature,
+                inExpectedDictionary: expectedHeaders,
+                toValueIn: changedPayloadHeaders,
+                shouldMatch: false)
+
+        compare(valueFor: .signature,
+                inExpectedDictionary: pathChangedHeaders,
+                toValueIn: changedPayloadHeaders,
+                shouldMatch: false)
 
     }
 

--- a/Tests/HeaderGenerationTests.swift
+++ b/Tests/HeaderGenerationTests.swift
@@ -52,7 +52,7 @@ class HeaderGenerationTests: XCTestCase {
         let expectedHeaders = [
             HeaderGenerator.HeaderField.timestamp.rawValue: timestamp,
             HeaderGenerator.HeaderField.address.rawValue: "0xa391af6a522436f335b7c6486640153641847ea2",
-            HeaderGenerator.HeaderField.signature.rawValue: "0x9098476693a6e7b24a722296138c9032388beea043d8b7e8ca30f21fdd79ca2c19c47d9e6acf4dec7dfc5f09f7003470b26a23035c68ccd10ba1a3b7e924fb1a00"
+            HeaderGenerator.HeaderField.signature.rawValue: "0x56c855458b2ad3be7f3ffe3ee4fe6c1bef5a7b7641ac90c55d5e507369bfc45312236498df05f346fe334769e7a3903a514ae4c30751056eab1f54672937a81201"
         ]
 
         let generatedHeaders = HeaderGenerator.createGetSignatureHeaders(path: path, cereal: testCereal, timestamp: timestamp)

--- a/Toshi.xcodeproj/project.pbxproj
+++ b/Toshi.xcodeproj/project.pbxproj
@@ -506,6 +506,7 @@
 		33DA846E2028D320008473F9 /* SegmentedHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DA846D2028D320008473F9 /* SegmentedHeaderView.swift */; };
 		33DA846F2028D320008473F9 /* SegmentedHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DA846D2028D320008473F9 /* SegmentedHeaderView.swift */; };
 		33DA84702028D320008473F9 /* SegmentedHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DA846D2028D320008473F9 /* SegmentedHeaderView.swift */; };
+		33E9A25B209CEBEE004621FF /* HeaderGenerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E9A25A209CEBEE004621FF /* HeaderGenerationTests.swift */; };
 		33EED15B1FE92C8B00C51EAC /* TSGroupModel+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EED15A1FE92C8B00C51EAC /* TSGroupModel+Additions.swift */; };
 		33EED15C1FE92E2600C51EAC /* TSGroupModel+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EED15A1FE92C8B00C51EAC /* TSGroupModel+Additions.swift */; };
 		33EED15D1FE92E2600C51EAC /* TSGroupModel+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EED15A1FE92C8B00C51EAC /* TSGroupModel+Additions.swift */; };
@@ -1443,6 +1444,7 @@
 		33CF51401FD56EA000293FD1 /* ProfilesAddedToGroupHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilesAddedToGroupHeader.swift; sourceTree = "<group>"; };
 		33D2ECFB1FFD1F3900AEFC4D /* contact.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = contact.json; sourceTree = "<group>"; };
 		33DA846D2028D320008473F9 /* SegmentedHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedHeaderView.swift; sourceTree = "<group>"; };
+		33E9A25A209CEBEE004621FF /* HeaderGenerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderGenerationTests.swift; sourceTree = "<group>"; };
 		33EED15A1FE92C8B00C51EAC /* TSGroupModel+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TSGroupModel+Additions.swift"; sourceTree = "<group>"; };
 		33EF275D2010D4690056699D /* DisappearingNavBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisappearingNavBarViewController.swift; sourceTree = "<group>"; };
 		33F1B9A61FCC3E3900D186AB /* TokenUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenUserTests.swift; sourceTree = "<group>"; };
@@ -1882,6 +1884,7 @@
 				D197BDA113837D7DCFE1A66F /* ExchangeRateAPIClientTests.swift */,
 				14147EA51E8119F0006BD47B /* Info.plist */,
 				33806076206274A200916E6A /* GeneratedCodeTests.swift */,
+				33E9A25A209CEBEE004621FF /* HeaderGenerationTests.swift */,
 				D197B0B8C43D9AEF28A5170A /* IDAPIClientQuickSpecs.swift */,
 				33816A6A2003CBF200FE81BD /* MessageParsingTests.swift */,
 				D197BD90B16E4CB6A71D4C6C /* NSDecimalNumber+AdditionsTests.swift */,
@@ -3758,6 +3761,7 @@
 				84C459021F41B7AA00D534B8 /* QRCodeIntentTests.swift in Sources */,
 				6AAB66321FC4508600C45149 /* CerealTests.swift in Sources */,
 				9FE5338A1F0B9CDA00B0C2B5 /* BaseConverter.swift in Sources */,
+				33E9A25B209CEBEE004621FF /* HeaderGenerationTests.swift in Sources */,
 				33CF51311FD181F700293FD1 /* DLog.swift in Sources */,
 				33731683200901BD0055975E /* String+AdditionsTests.swift in Sources */,
 				2BF2856D2018EF0200DA528D /* TestAppDelegate.swift in Sources */,

--- a/Toshi/APIClients/HeaderGenerator.swift
+++ b/Toshi/APIClients/HeaderGenerator.swift
@@ -51,7 +51,7 @@ struct HeaderGenerator {
         POST
     }
 
-    private enum HeaderField: String {
+    enum HeaderField: String {
         case
         address = "Toshi-ID-Address",
         contentLength = "Content-Length",

--- a/Toshi/APIClients/HeaderGenerator.swift
+++ b/Toshi/APIClients/HeaderGenerator.swift
@@ -27,23 +27,6 @@ enum HeaderGenerationError: Error {
 
 struct HeaderGenerator {
 
-    private static var testingCereal: Cereal?
-    static func defaultCereal() -> Cereal {
-        guard testingCereal == nil else {
-            return testingCereal!
-        }
-        return Cereal.shared
-    }
-
-    static func setTestingCereal(_ cereal: Cereal) {
-        testingCereal = cereal
-    }
-
-    static func clearTestingCereal() {
-        testingCereal = nil
-    
-    }
-
     enum HTTPMethod: String {
         case
         GET,
@@ -81,7 +64,7 @@ struct HeaderGenerator {
     static func createHeaders(timestamp: String,
                               path: String,
                               method: HTTPMethod = .POST,
-                              cereal: Cereal = defaultCereal(),
+                              cereal: Cereal = Cereal.shared,
                               payloadDictionary: [String: Any]) throws -> [String: String] {
         guard let data = try? JSONSerialization.data(withJSONObject: payloadDictionary, options: []) else {
             throw HeaderGenerationError.couldNotSerializePayloadDictionary
@@ -107,7 +90,7 @@ struct HeaderGenerator {
     static func createHeaders(timestamp: String,
                               path: String,
                               method: HTTPMethod = .POST,
-                              cereal: Cereal = defaultCereal(),
+                              cereal: Cereal = Cereal.shared,
                               payloadData: Data) throws -> [String: String] {
 
         guard let payloadString = String(data: payloadData, encoding: .utf8) else {
@@ -151,7 +134,7 @@ struct HeaderGenerator {
                                        timestamp: String,
                                        payload: Data,
                                        method: HTTPMethod = .POST,
-                                       cereal: Cereal = defaultCereal()) -> [String: String] {
+                                       cereal: Cereal = Cereal.shared) -> [String: String] {
         let hashedPayload = cereal.sha3WithID(data: payload)
         let signature = "0x\(cereal.signWithID(message: "\(method.rawValue)\n\(path)\n\(timestamp)\n\(hashedPayload)"))"
 
@@ -172,7 +155,7 @@ struct HeaderGenerator {
     ///   - timestamp: The timestamp to use when creating a header
     /// - Returns: A dictionary of string keys and string values which can be passed through as headers.
     static func createGetSignatureHeaders(path: String,
-                                          cereal: Cereal = defaultCereal(),
+                                          cereal: Cereal = Cereal.shared,
                                           timestamp: String) -> [String: String] {
         let signature = "0x\(cereal.signWithID(message: "\(HTTPMethod.GET.rawValue)\n\(path)\n\(timestamp)\n"))"
 

--- a/Toshi/Models/Users/APIPushInfo.swift
+++ b/Toshi/Models/Users/APIPushInfo.swift
@@ -28,7 +28,6 @@ struct APIPushInfo: Codable {
     }
 
     /// Grabs the default information for the user.
-    /// NOTE: You MUST call this on the main thread as it hits the app delegate.
     static var defaultInfo: APIPushInfo {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
             fatalError("Could not access the app delegate!")


### PR DESCRIPTION
Throwing a ton of stuff at this and making sure it gives us back expected data (and that signatures change when they should). 