### PR TITLE
[IOS-659] Implement add token service methods

### DIFF
--- a/Tests/AddTokenTests.swift
+++ b/Tests/AddTokenTests.swift
@@ -8,6 +8,7 @@ class AddTokenTests: XCTestCase {
     func testAddToken() {
 
         let mockTeapot = MockTeapot(bundle: Bundle(for: IDAPIClientTests.self), mockFilename: "")
+        mockTeapot.overrideEndPoint("timestamp", withFilename: "timestamp")
         let ethereumAPIClient = EthereumAPIClient(mockTeapot: mockTeapot)
 
         let expectation = XCTestExpectation(description: "adds a custom token")

--- a/Tests/AddTokenTests.swift
+++ b/Tests/AddTokenTests.swift
@@ -6,7 +6,6 @@ import Teapot
 class AddTokenTests: XCTestCase {
 
     func testAddToken() {
-
         let mockTeapot = MockTeapot(bundle: Bundle(for: IDAPIClientTests.self), mockFilename: "")
         mockTeapot.overrideEndPoint("timestamp", withFilename: "timestamp")
         let ethereumAPIClient = EthereumAPIClient(mockTeapot: mockTeapot)
@@ -24,9 +23,7 @@ class AddTokenTests: XCTestCase {
     }
 
     func testGetTokenWithAddress() {
-
         let mockTeapot = MockTeapot(bundle: Bundle(for: IDAPIClientTests.self), mockFilename: "0x4d8fc1453a0f359e99c9675954e656d80d996fbf")
-        mockTeapot.overrideEndPoint("timestamp", withFilename: "timestamp")
         let ethereumAPIClient = EthereumAPIClient(mockTeapot: mockTeapot)
 
         let expectation = XCTestExpectation(description: "gets token info by address")
@@ -38,8 +35,9 @@ class AddTokenTests: XCTestCase {
                 return
             }
             XCTAssertEqual(token.name, "Bee")
+            XCTAssertEqual(token.decimals, 18)
+            XCTAssertEqual(token.symbol, "BEE")
             expectation.fulfill()
-
          }
 
         wait(for: [expectation], timeout: 10.0)

--- a/Tests/AddTokenTests.swift
+++ b/Tests/AddTokenTests.swift
@@ -16,12 +16,6 @@ class AddTokenTests: XCTestCase {
         let mockTeapot = MockTeapot(bundle: Bundle(for: IDAPIClientTests.self), mockFilename: "")
         mockTeapot.overrideEndPoint("timestamp", withFilename: "timestamp")
         
-        mockTeapot.setExpectedHeaders([
-            "Toshi-ID-Address": "0xa391af6a522436f335b7c6486640153641847ea2",
-            "Toshi-Signature": "0xe79d6956ebbdeef75b4aaa8fdefc57150a8fcb81862fada405967d766df28cb4598a0d16fb970e73d97c29e3c1ddf3c2e0d76b3b4c5c58b26219740331a4580100",
-            "Toshi-Timestamp": "1503648141"
-        ])
-        
         let ethereumAPIClient = EthereumAPIClient(mockTeapot: mockTeapot)
 
         let expectation = XCTestExpectation(description: "adds a custom token")

--- a/Tests/AddTokenTests.swift
+++ b/Tests/AddTokenTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+import UIKit
+import Teapot
+@testable import Toshi
+
+class AddTokenTests: XCTestCase {
+
+    func testAddToken() {
+
+        let mockTeapot = MockTeapot(bundle: Bundle(for: IDAPIClientTests.self), mockFilename: "")
+        let ethereumAPIClient = EthereumAPIClient(mockTeapot: mockTeapot)
+
+        let expectation = XCTestExpectation(description: "adds a custom token")
+
+        let address = "0x4d8fc1453a0f359e99c9675954e656d80d996fbf"
+        ethereumAPIClient.addToken(with: address) { success, error in
+            XCTAssertTrue(success)
+            expectation.fulfill()
+
+         }
+        
+        wait(for: [expectation], timeout: 10.0)
+    }
+}

--- a/Tests/AddTokenTests.swift
+++ b/Tests/AddTokenTests.swift
@@ -22,4 +22,26 @@ class AddTokenTests: XCTestCase {
         
         wait(for: [expectation], timeout: 10.0)
     }
+
+    func testGetTokenWithAddress() {
+
+        let mockTeapot = MockTeapot(bundle: Bundle(for: IDAPIClientTests.self), mockFilename: "0x4d8fc1453a0f359e99c9675954e656d80d996fbf")
+        mockTeapot.overrideEndPoint("timestamp", withFilename: "timestamp")
+        let ethereumAPIClient = EthereumAPIClient(mockTeapot: mockTeapot)
+
+        let expectation = XCTestExpectation(description: "gets token info by address")
+
+        let address = "0x4d8fc1453a0f359e99c9675954e656d80d996fbf"
+        ethereumAPIClient.getToken(with: address) { token, error in
+            guard let token = token else {
+                XCTFail("nil token")
+                return
+            }
+            XCTAssertEqual(token.name, "Bee")
+            expectation.fulfill()
+
+         }
+
+        wait(for: [expectation], timeout: 10.0)
+    }
 }

--- a/Tests/AddTokenTests.swift
+++ b/Tests/AddTokenTests.swift
@@ -5,14 +5,11 @@ import Teapot
 
 class AddTokenTests: XCTestCase {
 
-    private var testCereal: Cereal {
-        guard let cereal = Cereal(words: ["abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "about"]) else {
-            fatalError("failed to create cereal")
-        }
-        return cereal
-    }
-
     func testAddToken() {
+        guard let testCereal = Cereal(words: ["abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "about"]) else {
+            XCTFail("failed to create cereal")
+            return
+        }
 
         Cereal.setSharedCereal(testCereal)
 

--- a/Tests/AddTokenTests.swift
+++ b/Tests/AddTokenTests.swift
@@ -13,10 +13,9 @@ class AddTokenTests: XCTestCase {
         let expectation = XCTestExpectation(description: "adds a custom token")
 
         let address = "0x4d8fc1453a0f359e99c9675954e656d80d996fbf"
-        ethereumAPIClient.addToken(with: address) { success, error in
+        ethereumAPIClient.addToken(with: address) { success, _ in
             XCTAssertTrue(success)
             expectation.fulfill()
-
          }
         
         wait(for: [expectation], timeout: 10.0)
@@ -29,7 +28,7 @@ class AddTokenTests: XCTestCase {
         let expectation = XCTestExpectation(description: "gets token info by address")
 
         let address = "0x4d8fc1453a0f359e99c9675954e656d80d996fbf"
-        ethereumAPIClient.getToken(with: address) { token, error in
+        ethereumAPIClient.getToken(with: address) { token, _ in
             guard let token = token else {
                 XCTFail("nil token")
                 return

--- a/Tests/AddTokenTests.swift
+++ b/Tests/AddTokenTests.swift
@@ -5,15 +5,32 @@ import Teapot
 
 class AddTokenTests: XCTestCase {
 
+    private var testCereal: Cereal {
+        guard let cereal = Cereal(words: ["abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "abandon", "about"]) else {
+            fatalError("failed to create cereal")
+        }
+        return cereal
+    }
+
     func testAddToken() {
+
+        Cereal.setSharedCereal(testCereal)
+
         let mockTeapot = MockTeapot(bundle: Bundle(for: IDAPIClientTests.self), mockFilename: "")
         mockTeapot.overrideEndPoint("timestamp", withFilename: "timestamp")
+        
+        mockTeapot.setExpectedHeaders([
+            "Toshi-ID-Address": "0xa391af6a522436f335b7c6486640153641847ea2",
+            "Toshi-Signature": "0xe79d6956ebbdeef75b4aaa8fdefc57150a8fcb81862fada405967d766df28cb4598a0d16fb970e73d97c29e3c1ddf3c2e0d76b3b4c5c58b26219740331a4580100",
+            "Toshi-Timestamp": "1503648141"
+        ])
+        
         let ethereumAPIClient = EthereumAPIClient(mockTeapot: mockTeapot)
 
         let expectation = XCTestExpectation(description: "adds a custom token")
 
         let address = "0x4d8fc1453a0f359e99c9675954e656d80d996fbf"
-        ethereumAPIClient.addToken(with: address) { success, _ in
+        ethereumAPIClient.addToken(with: address) { success, error in
             XCTAssertTrue(success)
             expectation.fulfill()
          }

--- a/Tests/Mocks/AddToken/0x4d8fc1453a0f359e99c9675954e656d80d996fbf.json
+++ b/Tests/Mocks/AddToken/0x4d8fc1453a0f359e99c9675954e656d80d996fbf.json
@@ -1,0 +1,5 @@
+{
+  "symbol": "BEE",
+  "name": "Bee",
+  "decimals": 18
+}

--- a/Toshi.xcodeproj/project.pbxproj
+++ b/Toshi.xcodeproj/project.pbxproj
@@ -1126,6 +1126,7 @@
 		D197BA1FF0BF6C862DE5FA1C /* ReceiptLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D197B65C63A525B97898821D /* ReceiptLineView.swift */; };
 		D197BA433CB02EDCAF1DE0AF /* AvatarTitleDescriptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D197B705981C3AED3EFB40DC /* AvatarTitleDescriptionCell.swift */; };
 		D197BA6E5DC09E84D524D1A2 /* getBalance.json in Resources */ = {isa = PBXBuildFile; fileRef = D197B003D276C7AD76B6A223 /* getBalance.json */; };
+		D197BA7C75306F339992A471 /* 0x4d8fc1453a0f359e99c9675954e656d80d996fbf.json in Resources */ = {isa = PBXBuildFile; fileRef = D197BC74C835CC9D5037BF98 /* 0x4d8fc1453a0f359e99c9675954e656d80d996fbf.json */; };
 		D197BA86BA0E50A255A50CD6 /* getCollectibles.json in Resources */ = {isa = PBXBuildFile; fileRef = D197B04967D7C10C90539A78 /* getCollectibles.json */; };
 		D197BA8AAC5425D906767D63 /* ReceiptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D197B2177A1D6D0ED2186291 /* ReceiptView.swift */; };
 		D197BA94CB5436F7605925FD /* SofaPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D197BC4FF536D4350C725251 /* SofaPayment.swift */; };
@@ -1699,6 +1700,7 @@
 		D197BC051BEE35DB98BD053F /* SofaInitialRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SofaInitialRequest.swift; sourceTree = "<group>"; };
 		D197BC2A4D26A2F961C2E33E /* SofaWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SofaWrapper.swift; sourceTree = "<group>"; };
 		D197BC4FF536D4350C725251 /* SofaPayment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SofaPayment.swift; sourceTree = "<group>"; };
+		D197BC74C835CC9D5037BF98 /* 0x4d8fc1453a0f359e99c9675954e656d80d996fbf.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = 0x4d8fc1453a0f359e99c9675954e656d80d996fbf.json; sourceTree = "<group>"; };
 		D197BCAEADF108A249EC0D89 /* SofaPaymentRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SofaPaymentRequest.swift; sourceTree = "<group>"; };
 		D197BCE7202958A0BA1A896E /* PaymentRouter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentRouter.swift; sourceTree = "<group>"; };
 		D197BCEB0A1FF98FE303EDBD /* SofaIdentifierTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SofaIdentifierTests.swift; sourceTree = "<group>"; };
@@ -2876,6 +2878,7 @@
 				D197B68934D29AC2FFC10D6C /* RatingsClient */,
 				D197B5FF695BD9EF008C10ED /* PaymentManager */,
 				D197B9040BBE8383C30B6F37 /* DirectoryAPIClient */,
+				D197BDB9531DFA96F8B87197 /* AddToken */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -3004,6 +3007,14 @@
 				D197B65C63A525B97898821D /* ReceiptLineView.swift */,
 			);
 			path = View;
+			sourceTree = "<group>";
+		};
+		D197BDB9531DFA96F8B87197 /* AddToken */ = {
+			isa = PBXGroup;
+			children = (
+				D197BC74C835CC9D5037BF98 /* 0x4d8fc1453a0f359e99c9675954e656d80d996fbf.json */,
+			);
+			path = AddToken;
 			sourceTree = "<group>";
 		};
 		E1A95D581E6F031F002762DA /* Views */ = {
@@ -3244,6 +3255,7 @@
 				D197BD13B1D92FA792BFA14C /* searchGroupProfiles.json in Resources */,
 				D197BEB3E29871D88732E16D /* searchUserProfiles.json in Resources */,
 				D197B4BEB15884E646D8683E /* searchBotProfiles.json in Resources */,
+				D197BA7C75306F339992A471 /* 0x4d8fc1453a0f359e99c9675954e656d80d996fbf.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Toshi.xcodeproj/project.pbxproj
+++ b/Toshi.xcodeproj/project.pbxproj
@@ -1164,6 +1164,7 @@
 		D197BF84F829C3200A677BE0 /* SofaPaymentRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D197BCAEADF108A249EC0D89 /* SofaPaymentRequest.swift */; };
 		D197BFB3C85D103063F9C87E /* ToshiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D197B54B1A4AD5DB747C55BF /* ToshiError.swift */; };
 		D197BFEFB82271BBE1152E9E /* SofaMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D197B3F77566E161C5CAB467 /* SofaMessage.swift */; };
+		D197BFF84CD1F312EC4C3803 /* AddTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D197BBAA667EA9A86F67E488 /* AddTokenTests.swift */; };
 		D197BFFC874FC46F485BE295 /* SofaPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = D197BC4FF536D4350C725251 /* SofaPayment.swift */; };
 		E1A95D551E6EF092002762DA /* SettingsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A95D541E6EF092002762DA /* SettingsController.swift */; };
 		E60A52A71F28DC5B0032CAC0 /* DevelopmentTokenURLPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E4D8CF1E72CB6E00389DF9 /* DevelopmentTokenURLPaths.swift */; };
@@ -1693,6 +1694,7 @@
 		D197BB0B32CD87852479976D /* CollectibleCellConfigurator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectibleCellConfigurator.swift; sourceTree = "<group>"; };
 		D197BB4FC8D408B73FE253E5 /* BlurView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlurView.swift; sourceTree = "<group>"; };
 		D197BB6208925B43A58D5483 /* PaymentConfirmationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentConfirmationViewController.swift; sourceTree = "<group>"; };
+		D197BBAA667EA9A86F67E488 /* AddTokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddTokenTests.swift; sourceTree = "<group>"; };
 		D197BBE7ED942198265AED9B /* String+nsRangeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+nsRangeTests.swift"; sourceTree = "<group>"; };
 		D197BC051BEE35DB98BD053F /* SofaInitialRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SofaInitialRequest.swift; sourceTree = "<group>"; };
 		D197BC2A4D26A2F961C2E33E /* SofaWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SofaWrapper.swift; sourceTree = "<group>"; };
@@ -1900,6 +1902,7 @@
 				D197BBE7ED942198265AED9B /* String+nsRangeTests.swift */,
 				9F3CF6A21FE143B600043530 /* TextTransformerTests.swift */,
 				D197B5CF9A6EFA209E1D74B5 /* IDAPIClientTests.swift */,
+				D197BBAA667EA9A86F67E488 /* AddTokenTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -3787,6 +3790,7 @@
 				D197BCD0784E03D9B662C7F8 /* CGFloat+Additions.swift in Sources */,
 				D197BCE9E48328BF70480029 /* DirectoryAPIClientTests.swift in Sources */,
 				D197B64168F50DA7F7EAC669 /* IDAPIClientTests.swift in Sources */,
+				D197BFF84CD1F312EC4C3803 /* AddTokenTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Toshi/APIClients/EthereumAPIClient.swift
+++ b/Toshi/APIClients/EthereumAPIClient.swift
@@ -354,12 +354,16 @@ final class EthereumAPIClient {
 
             let customTokenData = CustomToken(contractAddress: address, name: name, symbol: symbol, decimals: decimals)
             guard let jsonData = customTokenData.toOptionalJSONData() else {
-                completion(false, nil)
+                DispatchQueue.main.async {
+                    completion(false, nil)
+                }
                 return
             }
 
             guard let headers = try? HeaderGenerator.createHeaders(timestamp: timestamp, path: path, payloadData: jsonData) else {
-                completion(false, nil)
+                DispatchQueue.main.async {
+                    completion(false, nil)
+                }
                 return
             }
 

--- a/Toshi/APIClients/EthereumAPIClient.swift
+++ b/Toshi/APIClients/EthereumAPIClient.swift
@@ -347,6 +347,35 @@ final class EthereumAPIClient {
         }
     }
 
+    func addToken(with address: String, completion: @escaping ((_ success: Bool, _ error: ToshiError?) -> Void)) {
+        timestamp(mainTeapot) { timestamp, _ in
+            guard let timestamp = timestamp else { return }
+            let path = "/v1/token"
+
+            let info = ["contract_address": address]
+            guard let jsonData = info.toOptionalJSONData() else {
+                completion(false, nil)
+                return
+            }
+
+            guard let headers = try? HeaderGenerator.createHeaders(timestamp: timestamp, path: path, payloadData: jsonData) else {
+                completion(false, nil)
+                return
+            }
+
+            let json = RequestParameter(jsonData)
+
+            self.activeTeapot.post(path, parameters: json, headerFields: headers) { result in
+                switch result {
+                case .success(let json, let response):
+                    completion(true, nil)
+                case .failure(let json, let response, let error):
+                    completion(false, ToshiError(withTeapotError: error))
+                }
+            }
+        }
+    }
+
     // MARK: - Push Notifications
 
     func registerForMainNetworkPushNotifications() {

--- a/Toshi/APIClients/EthereumAPIClient.swift
+++ b/Toshi/APIClients/EthereumAPIClient.swift
@@ -390,6 +390,42 @@ final class EthereumAPIClient {
         }
     }
 
+    func getToken(with address: String, completion: @escaping ((_ token: CustomToken?, _ error: ToshiError?) -> Void)) {
+        self.activeTeapot.get("/v1/token/\(address)") { result in
+            var resultError: ToshiError?
+            var resultToken: CustomToken?
+
+            defer {
+                DispatchQueue.main.async {
+                    completion(resultToken, resultError)
+                }
+            }
+
+            switch result {
+            case .success(let json, let response):
+                guard response.statusCode == 200 else {
+                    resultError = .invalidResponseStatus(response.statusCode)
+                    return
+                }
+
+                guard let data = json?.data else {
+                    resultError = .invalidPayload
+                    return
+                }
+
+                CustomToken.fromJSONData(data,
+                        successCompletion: { token in
+                            resultToken = token
+                        },
+                        errorCompletion: { parsingError in
+                            resultError = parsingError
+                        })
+            case .failure(_, _, let error):
+                resultError = ToshiError(withTeapotError: error)
+            }
+        }
+    }
+
     // MARK: - Push Notifications
 
     func registerForMainNetworkPushNotifications() {

--- a/Toshi/Controllers/Wallet/Models/Token.swift
+++ b/Toshi/Controllers/Wallet/Models/Token.swift
@@ -139,3 +139,20 @@ extension Token: WalletItem {
         return symbol
     }
 }
+
+// MARK: - Custom Token
+
+struct CustomToken: Codable {
+    let contractAddress: String
+    let name: String?
+    let symbol: String?
+    let decimals: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case
+             contractAddress = "contract_address",
+             name,
+             symbol,
+             decimals
+    }
+}

--- a/Toshi/Controllers/Wallet/Models/Token.swift
+++ b/Toshi/Controllers/Wallet/Models/Token.swift
@@ -143,7 +143,7 @@ extension Token: WalletItem {
 // MARK: - Custom Token
 
 struct CustomToken: Codable {
-    let contractAddress: String
+    let contractAddress: String?
     let name: String?
     let symbol: String?
     let decimals: Int?


### PR DESCRIPTION
Added the two new API Calls and added tests for them

ADD CUSTOM ERC20 TOKEN:

> POST `/v1/token`
> Adds a custom erc20 token to the list of tokens, and/or forces a token to always show in the token balance list even if it has a 0 balance. Uses Toshi-ID authentication headers to proove ownership of an ethereum address.
> 
> name, symbol and decimals are optional, and the service will attempt to get the value from the contract metadata if they aren’t given.

SPECIFIC ERC20 TOKEN:

> GET /v1/token/{token_address}
> 
> Returns name, symbol and decimals for the given erc20 token

- I will add tests for the expected headers as well as soon as [bakkenbaeck/Teapot#33](url) is merged.
- I'm wondering if making the address optional in `CustomToken` struct is the good way to go. When adding a token this field is _not_ optional. But when getting specific token we use the address to return the three other fields. So to create the same `CustomToken` object from those results I had to make the address optional. I'm wondering if I should just add the address where the request was made with to the CustomToken tehre to make it non-optional.